### PR TITLE
:bug: fix draft.cs, return type fix (tuple -> array)

### DIFF
--- a/draft.cs
+++ b/draft.cs
@@ -40,7 +40,7 @@ namespace SecureLibrary
         //    }
         //}
         // Symmetric Encryption with AES CBC mode
-        public static (byte[] cipherText, byte[] iv) EncryptAesCbcWithIv(string plainText, byte[] key)
+        public static byte[][] EncryptAesCbcWithIv(string plainText, byte[] key)
         {
             using (Aes aes = Aes.Create())
             {
@@ -61,8 +61,8 @@ namespace SecureLibrary
                         cipherText = memoryStream.ToArray();
                     }
                 }
-
-                return (cipherText, aes.IV);
+                byte[] iv = aes.IV;
+                return new byte[][] { cipherText, iv };
             }
         }
 
@@ -92,7 +92,7 @@ namespace SecureLibrary
             }
         }
         // this section related about diffie hellman
-        public static (byte[] publicKey, byte[] privateKey) GenerateDiffieHellmanKeys()
+        public static byte[][] GenerateDiffieHellmanKeys()
         {
             using (ECDiffieHellmanCng dh = new ECDiffieHellmanCng())
             {
@@ -100,7 +100,7 @@ namespace SecureLibrary
                 dh.HashAlgorithm = CngAlgorithm.Sha256;
                 byte[] publicKey = dh.PublicKey.ToByteArray();
                 byte[] privateKey = dh.Key.Export(CngKeyBlobFormat.EccPrivateBlob);
-                return (publicKey, privateKey);
+                return new byte[][] { publicKey, privateKey };
             }
         }
 


### PR DESCRIPTION
This pull request includes changes to the `draft.cs` file, specifically within the `EncryptionHelper` class. The primary updates involve modifying the return types of several methods to use a jagged array format instead of tuples.

Changes to return types in encryption methods:

* `public static (byte[] cipherText, byte[] iv) EncryptAesCbcWithIv(string plainText, byte[] key)` now returns `byte[][]` instead of a tuple.
* Adjusted the return statement in `EncryptAesCbcWithIv` to return a jagged array `new byte[][] { cipherText, iv }` instead of a tuple.
* `public static (byte[] publicKey, byte[] privateKey) GenerateDiffieHellmanKeys()` now returns `byte[][]` instead of a tuple.
* Adjusted the return statement in `GenerateDiffieHellmanKeys` to return a jagged array `new byte[][] { publicKey, privateKey }` instead of a tuple.