### PR TITLE
9 enhance data deal as base64 encoded text instead of byte and make a method to create key

### DIFF
--- a/draft.cs
+++ b/draft.cs
@@ -91,6 +91,19 @@ namespace SecureLibrary
                 return Encoding.UTF8.GetString(decryptedBytes);
             }
         }
+
+        public static string KeyGenAES256()
+        {
+            using (Aes aes = Aes.Create())
+            {
+                aes.KeySize = 256;
+                aes.GenerateKey();
+                string base64key = ConvertToBase64String(aes.Key);
+            }
+            return base64key;
+        }
+
+        
         // this section related about diffie hellman
         public static byte[][] GenerateDiffieHellmanKeys()
         {

--- a/draft.cs
+++ b/draft.cs
@@ -105,8 +105,8 @@ namespace SecureLibrary
                 aes.KeySize = 256;
                 aes.GenerateKey();
                 string base64key = Convert.ToBase64String(aes.Key);
+                return base64key;
             }
-            return base64key;
         }
 
         

--- a/draft.cs
+++ b/draft.cs
@@ -40,8 +40,9 @@ namespace SecureLibrary
         //    }
         //}
         // Symmetric Encryption with AES CBC mode
-        public static byte[][] EncryptAesCbcWithIv(string plainText, byte[] key)
-        {
+        public static string[] EncryptAesCbcWithIv(string plainText, string base64Key)
+        {    
+            byte[] key = Convert.FromBase64String(base64Key); 
             using (Aes aes = Aes.Create())
             {
                 aes.Key = key;
@@ -61,13 +62,18 @@ namespace SecureLibrary
                         cipherText = memoryStream.ToArray();
                     }
                 }
-                byte[] iv = aes.IV;
-                return new byte[][] { cipherText, iv };
+                string base64CipherText = Convert.ToBase64String(cipherText);
+                string base64IV = Convert.ToBase64String(aes.IV);
+                return new string[] { base64CipherText, base64IV };
             }
         }
 
-        public static string DecryptAesCbcWithIv(byte[] cipherText, byte[] key, byte[] iv)
+        public static string DecryptAesCbcWithIv(string base64CipherText, string base64Key, string base64IV)
         {
+            byte[] key = Convert.FromBase64String(base64Key);
+            byte[] cipherText = Convert.FromBase64String(base64CipherText);
+            byte[] iv = Convert.FromBase64String(base64IV);
+
             using (Aes aes = Aes.Create())
             {
                 aes.Key = key;

--- a/draft.cs
+++ b/draft.cs
@@ -104,7 +104,7 @@ namespace SecureLibrary
             {
                 aes.KeySize = 256;
                 aes.GenerateKey();
-                string base64key = ConvertToBase64String(aes.Key);
+                string base64key = Convert.ToBase64String(aes.Key);
             }
             return base64key;
         }


### PR DESCRIPTION
This pull request includes changes to the `draft.cs` file to update the encryption methods and add a new key generation method. The most important changes include modifying the `EncryptAesCbcWithIv` and `DecryptAesCbcWithIv` methods to use base64 strings, and adding a new method for AES-256 key generation.

### Encryption method updates:

* `EncryptAesCbcWithIv` method: Changed the parameters to accept base64 encoded strings and updated the return type to base64 encoded strings. [[1]](diffhunk://#diff-7dfb06e0bba242988f6b0ce078de9128fa1e1241bf4506801f0fbf929f7f73fcL43-R45) [[2]](diffhunk://#diff-7dfb06e0bba242988f6b0ce078de9128fa1e1241bf4506801f0fbf929f7f73fcL64-R76)
* `DecryptAesCbcWithIv` method: Changed the parameters to accept base64 encoded strings and updated the internal logic to handle base64 encoded strings. [[1]](diffhunk://#diff-7dfb06e0bba242988f6b0ce078de9128fa1e1241bf4506801f0fbf929f7f73fcL64-R76) [[2]](diffhunk://#diff-7dfb06e0bba242988f6b0ce078de9128fa1e1241bf4506801f0fbf929f7f73fcR100-R112)

### New method addition:

* Added `KeyGenAES256` method: This method generates a new AES-256 key and returns it as a base64 encoded string.