### PR TITLE
Fix/readme/250203 build example link

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -44,7 +44,7 @@
 ## 빌드 관련 정보
 지원하는 windows 환경에서 빌드하실 수 있으며
 필요한 명령어는
-[github actions](https://github.com/yuseok-kim-edushare/simple-.net-Crypting-For-PowerBuilder/actions/workflows)
+[github actions](https://github.com/yuseok-kim-edushare/simple-.net-Crypting-For-PowerBuilder/tree/main/.github/workflows)
 에서 확인하실 수 있습니다.
 ci.yaml과 cd.yaml 확인하시면 됩니다.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For Example
 ## Build Information
 You can build in supported windows environment,
 and you can check required commands in
-[github actions](https://github.com/yuseok-kim-edushare/simple-.net-Crypting-For-PowerBuilder/actions/workflows)
+[github actions](https://github.com/yuseok-kim-edushare/simple-.net-Crypting-For-PowerBuilder/tree/main/.github/workflows)
 you should see ci.yaml and cd.yaml
 
 # Dependancy


### PR DESCRIPTION
This pull request includes updates to the `README` files to correct the links to the GitHub Actions workflows. The most important changes are:

Updates to documentation:

* [`README.ko.md`](diffhunk://#diff-86fa6921bcebf260d55d8a3742c1b513bd78f4ea18366db989b5a03c68c563aeL47-R47): Updated the link to the GitHub Actions workflows to point to the correct directory.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L47-R47): Corrected the link to the GitHub Actions workflows to ensure it points to the main branch directory.