### PR TITLE
🛂 add password based encryption

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -51,9 +51,8 @@ jobs:
             console.log('Auto-merge has been enabled for dependabot PR.');
             
       - name: Notify about auto-merge enablement
-        if: steps.check_dependabot.outputs.is_dependabot == 'true'
         run: |
-          echo "Auto-merge has been enabled for dependabot PR #${{ github.event.pull_request.number }}"
+          echo "Auto-merge has been enabled for PR #${{ github.event.pull_request.number }}"
           echo "The CD workflow will be triggered automatically after merge."
           
       - name: Trigger CD workflow for dependabot auto-merge
@@ -75,7 +74,7 @@ jobs:
             console.log('Repository dispatch event sent to trigger CD workflow for dependabot auto-merge');
       
       - name: Trigger CD workflow for non-dependabot auto-merge
-        if: steps.check_dependabot.outputs.is_dependabot == 'true'
+        if: steps.check_dependabot.outputs.is_dependabot == 'false'
         uses: actions/github-script@v7
         with:
           script: |

--- a/NET8/e2etest.cs
+++ b/NET8/e2etest.cs
@@ -80,6 +80,7 @@ namespace SecureLibrary.Tests
         // CLR requires special security permissions, so these tests are included here separately
         // Thus, these tests are included here to test the SQL CLR code in the SecureLibrary-SQL project
         [TestMethod]
+        [TestCategory("SQLCLR")]
         public void TestSqlCLR_GenerateAESKey()
         {
             // Act
@@ -91,6 +92,7 @@ namespace SecureLibrary.Tests
         }
         
         [TestMethod]
+        [TestCategory("SQLCLR")]
         public void TestSqlCLR_EncryptAES()
         {
             // Arrange
@@ -106,6 +108,7 @@ namespace SecureLibrary.Tests
         }
         
         [TestMethod]
+        [TestCategory("SQLCLR")]
         public void TestSqlCLR_HashPassword()
         {
             // Arrange
@@ -120,6 +123,7 @@ namespace SecureLibrary.Tests
         }
         
         [TestMethod]
+        [TestCategory("SQLCLR")]
         public void TestSqlCLR_VerifyPassword()
         {
             // Arrange
@@ -136,6 +140,7 @@ namespace SecureLibrary.Tests
         }
 
         [TestMethod]
+        [TestCategory("SQLCLR")]
         public void TestSqlCLR_GenerateDiffieHellmanKeys()
         {
             // Act
@@ -147,6 +152,7 @@ namespace SecureLibrary.Tests
         }
 
         [TestMethod]
+        [TestCategory("SQLCLR")]
         public void TestSqlCLR_DeriveSharedKey()
         {
             // Arrange
@@ -164,6 +170,7 @@ namespace SecureLibrary.Tests
         }
 
         [TestMethod]
+        [TestCategory("SQLCLR")]
         public void TestSqlCLR_EncryptAesGcm()
         {
             // Arrange
@@ -196,6 +203,8 @@ namespace SecureLibrary.Tests
 
         // New tests for password-based AES-GCM encryption
         [TestMethod]
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+        [TestCategory("SQLCLR")]
         public void TestSqlCLR_EncryptAesGcmWithPassword()
         {
             // Arrange
@@ -222,6 +231,7 @@ namespace SecureLibrary.Tests
         }
 
         [TestMethod]
+        [TestCategory("SQLCLR")]
         public void TestSqlCLR_EncryptAesGcmWithPassword_CustomIterations()
         {
             // Arrange
@@ -242,6 +252,7 @@ namespace SecureLibrary.Tests
         }
 
         [TestMethod]
+        [TestCategory("SQLCLR")]
         public void TestSqlCLR_EncryptAesGcmWithPassword_DifferentIterationsShouldFail()
         {
             // Arrange
@@ -262,6 +273,7 @@ namespace SecureLibrary.Tests
         }
 
         [TestMethod]
+        [TestCategory("SQLCLR")]
         public void TestSqlCLR_GenerateSalt()
         {
             // Act
@@ -277,6 +289,7 @@ namespace SecureLibrary.Tests
         }
 
         [TestMethod]
+        [TestCategory("SQLCLR")]
         public void TestSqlCLR_GenerateSalt_CustomLength()
         {
             // Arrange
@@ -294,6 +307,7 @@ namespace SecureLibrary.Tests
         }
 
         [TestMethod]
+        [TestCategory("SQLCLR")]
         public void TestSqlCLR_GenerateSalt_InvalidLength()
         {
             // Arrange
@@ -309,6 +323,7 @@ namespace SecureLibrary.Tests
         }
 
         [TestMethod]
+        [TestCategory("SQLCLR")]
         public void TestSqlCLR_EncryptAesGcmWithPasswordAndSalt()
         {
             // Arrange
@@ -331,6 +346,7 @@ namespace SecureLibrary.Tests
         }
 
         [TestMethod]
+        [TestCategory("SQLCLR")]
         public void TestSqlCLR_EncryptAesGcmWithPasswordAndSalt_CustomIterations()
         {
             // Arrange
@@ -354,6 +370,7 @@ namespace SecureLibrary.Tests
         }
 
         [TestMethod]
+        [TestCategory("SQLCLR")]
         public void TestSqlCLR_PasswordBasedEncryption_CrossCompatibility()
         {
             // Test that the same password produces different encrypted results (due to random salt/nonce)
@@ -378,6 +395,7 @@ namespace SecureLibrary.Tests
         }
 
         [TestMethod]
+        [TestCategory("SQLCLR")]
         public void TestSqlCLR_PasswordBasedEncryption_InvalidInputs()
         {
             // Test null inputs
@@ -393,6 +411,7 @@ namespace SecureLibrary.Tests
         }
 
         [TestMethod]
+        [TestCategory("SQLCLR")]
         public void TestSqlCLR_PasswordBasedEncryption_InvalidIterations()
         {
             // Arrange
@@ -410,6 +429,7 @@ namespace SecureLibrary.Tests
         }
 
         [TestMethod]
+        [TestCategory("SQLCLR")]
         public void TestSqlCLR_PasswordBasedEncryption_LargeData()
         {
             // Arrange
@@ -428,6 +448,7 @@ namespace SecureLibrary.Tests
         }
 
         [TestMethod]
+        [TestCategory("SQLCLR")]
         public void TestSqlCLR_PasswordBasedEncryption_SpecialCharacters()
         {
             // Arrange
@@ -446,6 +467,7 @@ namespace SecureLibrary.Tests
         }
 
         [TestMethod]
+        [TestCategory("SQLCLR")]
         public void TestSqlCLR_PasswordBasedEncryption_UnicodeCharacters()
         {
             // Arrange

--- a/NET8/test.cs
+++ b/NET8/test.cs
@@ -2,6 +2,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SecureLibrary;
 using System;
+using System.Security.Cryptography;
 
 namespace SecureLibrary.Tests
 {
@@ -67,6 +68,229 @@ namespace SecureLibrary.Tests
             // Assert
             Assert.IsTrue(isValid);
             Assert.IsFalse(isInvalid);
+        }
+
+        // Password-based AES-GCM encryption tests
+        [TestMethod]
+        public void TestPasswordBasedAesGcmEncryptionDecryption()
+        {
+            // Arrange
+            string plainText = "Hello, World!";
+            string password = "MySecurePassword123";
+
+            // Act
+            string encrypted = EncryptionHelper.EncryptAesGcmWithPassword(plainText, password);
+            string decrypted = EncryptionHelper.DecryptAesGcmWithPassword(encrypted, password);
+
+            // Assert
+            Assert.AreEqual(plainText, decrypted);
+        }
+
+        [TestMethod]
+        public void TestPasswordBasedAesGcmWithCustomIterations()
+        {
+            // Arrange
+            string plainText = "Test with custom iterations";
+            string password = "MyPassword";
+            int iterations = 5000;
+
+            // Act
+            string encrypted = EncryptionHelper.EncryptAesGcmWithPassword(plainText, password, iterations);
+            string decrypted = EncryptionHelper.DecryptAesGcmWithPassword(encrypted, password, iterations);
+
+            // Assert
+            Assert.AreEqual(plainText, decrypted);
+        }
+
+        [TestMethod]
+        public void TestPasswordBasedAesGcmDifferentIterationsShouldFail()
+        {
+            // Arrange
+            string plainText = "Test with different iterations";
+            string password = "MyPassword";
+            int encryptIterations = 2000;
+            int decryptIterations = 5000;
+
+            // Act
+            string encrypted = EncryptionHelper.EncryptAesGcmWithPassword(plainText, password, encryptIterations);
+            
+            // Assert - Should throw exception due to wrong iterations
+            Assert.ThrowsException<CryptographicException>(() => 
+                EncryptionHelper.DecryptAesGcmWithPassword(encrypted, password, decryptIterations));
+        }
+
+        [TestMethod]
+        public void TestGenerateSalt()
+        {
+            // Act
+            string salt = EncryptionHelper.GenerateSalt();
+            
+            // Assert
+            Assert.IsNotNull(salt);
+            Assert.AreEqual(24, salt.Length); // 16 bytes = 24 chars in base64
+            
+            // Validate it's valid base64
+            byte[] saltBytes = Convert.FromBase64String(salt);
+            Assert.AreEqual(16, saltBytes.Length);
+        }
+
+        [TestMethod]
+        public void TestGenerateSaltCustomLength()
+        {
+            // Arrange
+            int saltLength = 32;
+            
+            // Act
+            string salt = EncryptionHelper.GenerateSalt(saltLength);
+            
+            // Assert
+            Assert.IsNotNull(salt);
+            
+            // Validate it's valid base64 and correct length
+            byte[] saltBytes = Convert.FromBase64String(salt);
+            Assert.AreEqual(32, saltBytes.Length);
+        }
+
+        [TestMethod]
+        public void TestGenerateSaltInvalidLength()
+        {
+            // Arrange
+            int tooSmall = 4;  // Below minimum of 8
+            int tooLarge = 128; // Above maximum of 64
+            
+            // Act & Assert
+            Assert.ThrowsException<ArgumentException>(() => EncryptionHelper.GenerateSalt(tooSmall));
+            Assert.ThrowsException<ArgumentException>(() => EncryptionHelper.GenerateSalt(tooLarge));
+        }
+
+        [TestMethod]
+        public void TestPasswordBasedAesGcmWithCustomSalt()
+        {
+            // Arrange
+            string plainText = "Test with custom salt";
+            string password = "MyPassword";
+            string salt = EncryptionHelper.GenerateSalt();
+            
+            // Act
+            string encrypted = EncryptionHelper.EncryptAesGcmWithPasswordAndSalt(plainText, password, salt);
+            string decrypted = EncryptionHelper.DecryptAesGcmWithPassword(encrypted, password);
+            
+            // Assert
+            Assert.AreEqual(plainText, decrypted);
+        }
+
+        [TestMethod]
+        public void TestPasswordBasedAesGcmWithCustomSaltAndIterations()
+        {
+            // Arrange
+            string plainText = "Test with custom salt and iterations";
+            string password = "MyPassword";
+            string salt = EncryptionHelper.GenerateSalt(24);
+            int iterations = 3000;
+            
+            // Act
+            string encrypted = EncryptionHelper.EncryptAesGcmWithPasswordAndSalt(plainText, password, salt, iterations);
+            string decrypted = EncryptionHelper.DecryptAesGcmWithPassword(encrypted, password, iterations);
+            
+            // Assert
+            Assert.AreEqual(plainText, decrypted);
+        }
+
+        [TestMethod]
+        public void TestPasswordBasedAesGcmCrossCompatibility()
+        {
+            // Test that the same password produces different encrypted results (due to random salt/nonce)
+            string plainText = "Same text, different encryption";
+            string password = "MyPassword";
+            
+            // Act - Encrypt same text twice
+            string encrypted1 = EncryptionHelper.EncryptAesGcmWithPassword(plainText, password);
+            string encrypted2 = EncryptionHelper.EncryptAesGcmWithPassword(plainText, password);
+            
+            // Assert - Results should be different due to random salt/nonce
+            Assert.AreNotEqual(encrypted1, encrypted2);
+            
+            // But both should decrypt to the same plaintext
+            string decrypted1 = EncryptionHelper.DecryptAesGcmWithPassword(encrypted1, password);
+            string decrypted2 = EncryptionHelper.DecryptAesGcmWithPassword(encrypted2, password);
+            
+            Assert.AreEqual(plainText, decrypted1);
+            Assert.AreEqual(plainText, decrypted2);
+        }
+
+        [TestMethod]
+        public void TestPasswordBasedAesGcmInvalidInputs()
+        {
+            // Test null inputs
+            Assert.ThrowsException<ArgumentNullException>(() => 
+                EncryptionHelper.EncryptAesGcmWithPassword(null, "password"));
+            Assert.ThrowsException<ArgumentNullException>(() => 
+                EncryptionHelper.EncryptAesGcmWithPassword("text", null));
+            Assert.ThrowsException<ArgumentNullException>(() => 
+                EncryptionHelper.DecryptAesGcmWithPassword(null, "password"));
+            Assert.ThrowsException<ArgumentNullException>(() => 
+                EncryptionHelper.DecryptAesGcmWithPassword("data", null));
+        }
+
+        [TestMethod]
+        public void TestPasswordBasedAesGcmInvalidIterations()
+        {
+            // Arrange
+            string plainText = "Test invalid iterations";
+            string password = "MyPassword";
+            int tooLow = 500;   // Below minimum of 1000
+            int tooHigh = 200000; // Above maximum of 100000
+            
+            // Act & Assert
+            Assert.ThrowsException<ArgumentException>(() => 
+                EncryptionHelper.EncryptAesGcmWithPassword(plainText, password, tooLow));
+            Assert.ThrowsException<ArgumentException>(() => 
+                EncryptionHelper.EncryptAesGcmWithPassword(plainText, password, tooHigh));
+        }
+
+        [TestMethod]
+        public void TestPasswordBasedAesGcmLargeData()
+        {
+            // Arrange
+            string largeText = new string('A', 10000); // 10KB of data
+            string password = "MyPassword";
+            
+            // Act
+            string encrypted = EncryptionHelper.EncryptAesGcmWithPassword(largeText, password);
+            string decrypted = EncryptionHelper.DecryptAesGcmWithPassword(encrypted, password);
+            
+            // Assert
+            Assert.AreEqual(largeText, decrypted);
+        }
+
+        [TestMethod]
+        public void TestPasswordBasedAesGcmSpecialCharacters()
+        {
+            // Arrange
+            string specialText = "Special chars: !@#$%^&*()_+-=[]{}|;':\",./<>?`~";
+            string password = "Password with spaces and symbols: !@#";
+            
+            // Act
+            string encrypted = EncryptionHelper.EncryptAesGcmWithPassword(specialText, password);
+            string decrypted = EncryptionHelper.DecryptAesGcmWithPassword(encrypted, password);
+            
+            // Assert
+            Assert.AreEqual(specialText, decrypted);
+        }
+
+        [TestMethod]
+        public void TestPasswordBasedAesGcmUnicodeCharacters()
+        {
+            // Arrange
+            string unicodeText = "Unicode: 你好世界 🌍 🚀 こんにちは";
+            string password = "Unicode password: パスワード";
+            
+            // Act
+            string encrypted = EncryptionHelper.EncryptAesGcmWithPassword(unicodeText, password);
+            string decrypted = EncryptionHelper.DecryptAesGcmWithPassword(encrypted, password);
+            
+            // Assert
+            Assert.AreEqual(unicodeText, decrypted);
         }
     }
 }

--- a/NET8/test.cs
+++ b/NET8/test.cs
@@ -115,7 +115,7 @@ namespace SecureLibrary.Tests
             string encrypted = EncryptionHelper.EncryptAesGcmWithPassword(plainText, password, encryptIterations);
             
             // Assert - Should throw exception due to wrong iterations
-            Assert.ThrowsException<CryptographicException>(() => 
+            Assert.ThrowsException<AuthenticationTagMismatchException>(() => 
                 EncryptionHelper.DecryptAesGcmWithPassword(encrypted, password, decryptIterations));
         }
 

--- a/net481PB/invokeCGN.cs
+++ b/net481PB/invokeCGN.cs
@@ -284,5 +284,346 @@ namespace SecureLibrary
                 if (plainText != null) Array.Clear(plainText, 0, plainText.Length);
             }
         }
+
+        // Password-based AES-GCM encryption methods
+        /// <summary>
+        /// Encrypts string using AES-GCM with password-based key derivation
+        /// </summary>
+        /// <param name="plainText">Text to encrypt</param>
+        /// <param name="password">Password for key derivation</param>
+        /// <param name="salt">Salt for key derivation (optional, will generate if null)</param>
+        /// <param name="iterations">PBKDF2 iteration count (default: 2000)</param>
+        /// <returns>Base64 encoded encrypted data with salt, nonce, and tag</returns>
+        public static string EncryptAesGcmWithPassword(string plainText, string password, byte[] salt = null, int iterations = 2000)
+        {
+            if (plainText == null) throw new ArgumentNullException("plainText");
+            if (string.IsNullOrEmpty(password)) throw new ArgumentNullException("password");
+
+            byte[] plainBytes = Encoding.UTF8.GetBytes(plainText);
+            byte[] encryptedBytes = EncryptAesGcmBytes(plainBytes, password, salt, iterations);
+            
+            // Clear sensitive data
+            Array.Clear(plainBytes, 0, plainBytes.Length);
+            
+            return Convert.ToBase64String(encryptedBytes);
+        }
+
+        /// <summary>
+        /// Decrypts string using AES-GCM with password-based key derivation
+        /// </summary>
+        /// <param name="base64EncryptedData">Base64 encoded encrypted data</param>
+        /// <param name="password">Password for key derivation</param>
+        /// <param name="iterations">PBKDF2 iteration count (default: 2000)</param>
+        /// <returns>Decrypted text</returns>
+        public static string DecryptAesGcmWithPassword(string base64EncryptedData, string password, int iterations = 2000)
+        {
+            if (string.IsNullOrEmpty(base64EncryptedData)) throw new ArgumentNullException("base64EncryptedData");
+            if (string.IsNullOrEmpty(password)) throw new ArgumentNullException("password");
+
+            byte[] encryptedBytes = Convert.FromBase64String(base64EncryptedData);
+            byte[] decryptedBytes = DecryptAesGcmBytes(encryptedBytes, password, iterations);
+            
+            string result = Encoding.UTF8.GetString(decryptedBytes);
+            
+            // Clear sensitive data
+            Array.Clear(encryptedBytes, 0, encryptedBytes.Length);
+            Array.Clear(decryptedBytes, 0, decryptedBytes.Length);
+            
+            return result;
+        }
+
+        /// <summary>
+        /// Encrypts byte array using AES-GCM with password-based key derivation
+        /// </summary>
+        /// <param name="plainData">Data to encrypt</param>
+        /// <param name="password">Password for key derivation</param>
+        /// <param name="salt">Salt for key derivation (optional, will generate if null)</param>
+        /// <param name="iterations">PBKDF2 iteration count (default: 2000)</param>
+        /// <returns>Encrypted data with salt, nonce, and tag</returns>
+        public static byte[] EncryptAesGcmBytes(byte[] plainData, string password, byte[] salt = null, int iterations = 2000)
+        {
+            if (plainData == null) throw new ArgumentNullException("plainData");
+            if (string.IsNullOrEmpty(password)) throw new ArgumentNullException("password");
+
+            // Generate salt if not provided
+            if (salt == null)
+            {
+                salt = new byte[16];
+                using (var rng = new RNGCryptoServiceProvider())
+                {
+                    rng.GetBytes(salt);
+                }
+            }
+
+            // Derive 32-byte key from password
+            byte[] key;
+            using (var pbkdf2 = new Rfc2898DeriveBytes(password, salt, iterations, HashAlgorithmName.SHA256))
+            {
+                key = pbkdf2.GetBytes(32);
+            }
+
+            // Generate 12-byte nonce
+            byte[] nonce = new byte[12];
+            using (var rng = new RNGCryptoServiceProvider())
+            {
+                rng.GetBytes(nonce);
+            }
+
+            byte[] encryptedData = EncryptAesGcmBytes(plainData, key, nonce);
+
+            // Combine salt + nonce + encrypted data for output
+            byte[] result = new byte[salt.Length + nonce.Length + encryptedData.Length];
+            Buffer.BlockCopy(salt, 0, result, 0, salt.Length);
+            Buffer.BlockCopy(nonce, 0, result, salt.Length, nonce.Length);
+            Buffer.BlockCopy(encryptedData, 0, result, salt.Length + nonce.Length, encryptedData.Length);
+
+            // Clear sensitive data
+            Array.Clear(key, 0, key.Length);
+            Array.Clear(nonce, 0, nonce.Length);
+            Array.Clear(encryptedData, 0, encryptedData.Length);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Decrypts byte array using AES-GCM with password-based key derivation
+        /// </summary>
+        /// <param name="encryptedData">Encrypted data with salt, nonce, and tag</param>
+        /// <param name="password">Password for key derivation</param>
+        /// <param name="iterations">PBKDF2 iteration count (default: 2000)</param>
+        /// <returns>Decrypted data</returns>
+        public static byte[] DecryptAesGcmBytes(byte[] encryptedData, string password, int iterations = 2000)
+        {
+            if (encryptedData == null) throw new ArgumentNullException("encryptedData");
+            if (string.IsNullOrEmpty(password)) throw new ArgumentNullException("password");
+
+            const int nonceLength = 12;
+            const int tagLength = 16;
+            const int minSaltLength = 8;
+            const int maxSaltLength = 64;
+
+            if (encryptedData.Length < minSaltLength + nonceLength + tagLength)
+                throw new ArgumentException("Encrypted data too short", "encryptedData");
+
+            // Determine salt length by trying different lengths
+            for (int testSaltLength = minSaltLength; testSaltLength <= maxSaltLength && testSaltLength <= encryptedData.Length - nonceLength - tagLength; testSaltLength++)
+            {
+                try
+                {
+                    byte[] salt = new byte[testSaltLength];
+                    byte[] nonce = new byte[nonceLength];
+                    byte[] cipherWithTag = new byte[encryptedData.Length - testSaltLength - nonceLength];
+
+                    Buffer.BlockCopy(encryptedData, 0, salt, 0, testSaltLength);
+                    Buffer.BlockCopy(encryptedData, testSaltLength, nonce, 0, nonceLength);
+                    Buffer.BlockCopy(encryptedData, testSaltLength + nonceLength, cipherWithTag, 0, cipherWithTag.Length);
+
+                    // Try to derive key and decrypt
+                    byte[] key;
+                    using (var pbkdf2 = new Rfc2898DeriveBytes(password, salt, iterations, HashAlgorithmName.SHA256))
+                    {
+                        key = pbkdf2.GetBytes(32);
+                    }
+
+                    byte[] result = DecryptAesGcmBytes(cipherWithTag, key, nonce);
+                    
+                    // Clear sensitive data
+                    Array.Clear(salt, 0, salt.Length);
+                    Array.Clear(nonce, 0, nonce.Length);
+                    Array.Clear(cipherWithTag, 0, cipherWithTag.Length);
+                    Array.Clear(key, 0, key.Length);
+                    
+                    return result;
+                }
+                catch
+                {
+                    // Continue to next salt length
+                }
+            }
+
+            // If we get here, no salt length worked
+            throw new CryptographicException("Failed to decrypt data with any valid salt length");
+        }
+
+        /// <summary>
+        /// Encrypts byte array using AES-GCM with provided key and nonce
+        /// </summary>
+        /// <param name="plainData">Data to encrypt</param>
+        /// <param name="key">32-byte encryption key</param>
+        /// <param name="nonce">12-byte nonce</param>
+        /// <returns>Encrypted data with authentication tag</returns>
+        public static byte[] EncryptAesGcmBytes(byte[] plainData, byte[] key, byte[] nonce)
+        {
+            if (plainData == null) throw new ArgumentNullException("plainData");
+            if (key == null) throw new ArgumentNullException("key");
+            if (nonce == null) throw new ArgumentNullException("nonce");
+
+            if (key.Length != 32) throw new ArgumentException("Key must be 32 bytes", "key");
+            if (nonce.Length != 12) throw new ArgumentException("Nonce must be 12 bytes", "nonce");
+
+            IntPtr hAlg = IntPtr.Zero;
+            IntPtr hKey = IntPtr.Zero;
+
+            try
+            {
+                // Initialize algorithm provider
+                int status = BCryptOpenAlgorithmProvider(out hAlg, BCRYPT_AES_ALGORITHM, null, 0);
+                if (status != STATUS_SUCCESS) throw new CryptographicException("BCryptOpenAlgorithmProvider failed with status " + status);
+
+                // Set GCM mode
+                status = BCryptSetProperty(hAlg, BCRYPT_CHAINING_MODE, 
+                    Encoding.Unicode.GetBytes(BCRYPT_CHAIN_MODE_GCM), 
+                    Encoding.Unicode.GetBytes(BCRYPT_CHAIN_MODE_GCM).Length, 0);
+                if (status != STATUS_SUCCESS) throw new CryptographicException("BCryptSetProperty failed with status " + status);
+
+                // Generate key
+                status = BCryptGenerateSymmetricKey(hAlg, out hKey, IntPtr.Zero, 0, key, key.Length, 0);
+                if (status != STATUS_SUCCESS) throw new CryptographicException("BCryptGenerateSymmetricKey failed with status " + status);
+
+                const int tagLength = 16;  // GCM tag length
+
+                var authInfo = BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO.Initialize();
+                var nonceHandle = GCHandle.Alloc(nonce, GCHandleType.Pinned);
+                var tagBuffer = new byte[tagLength];
+                var tagHandle = GCHandle.Alloc(tagBuffer, GCHandleType.Pinned);
+
+                try
+                {
+                    authInfo.pbNonce = nonceHandle.AddrOfPinnedObject();
+                    authInfo.cbNonce = nonce.Length;
+                    authInfo.pbTag = tagHandle.AddrOfPinnedObject();
+                    authInfo.cbTag = tagLength;
+
+                    // Get required size
+                    int cipherLength;
+                    status = BCryptEncrypt(hKey, plainData, plainData.Length, ref authInfo,
+                        null, 0, null, 0, out cipherLength, 0);
+                    if (status != STATUS_SUCCESS) throw new CryptographicException("BCryptEncrypt size failed with status " + status);
+
+                    byte[] cipherText = new byte[cipherLength];
+
+                    // Encrypt
+                    int bytesWritten;
+                    status = BCryptEncrypt(hKey, plainData, plainData.Length, ref authInfo,
+                        null, 0, cipherText, cipherText.Length, out bytesWritten, 0);
+                    if (status != STATUS_SUCCESS) throw new CryptographicException("BCryptEncrypt failed with status " + status);
+
+                    // Combine ciphertext and tag
+                    byte[] result = new byte[bytesWritten + tagLength];
+                    Buffer.BlockCopy(cipherText, 0, result, 0, bytesWritten);
+                    Buffer.BlockCopy(tagBuffer, 0, result, bytesWritten, tagLength);
+
+                    // Clear sensitive data
+                    Array.Clear(cipherText, 0, cipherText.Length);
+                    Array.Clear(tagBuffer, 0, tagBuffer.Length);
+
+                    return result;
+                }
+                finally
+                {
+                    if (nonceHandle.IsAllocated) nonceHandle.Free();
+                    if (tagHandle.IsAllocated) tagHandle.Free();
+                }
+            }
+            finally
+            {
+                if (hKey != IntPtr.Zero) BCryptDestroyKey(hKey);
+                if (hAlg != IntPtr.Zero) BCryptCloseAlgorithmProvider(hAlg, 0);
+            }
+        }
+
+        /// <summary>
+        /// Decrypts byte array using AES-GCM with provided key and nonce
+        /// </summary>
+        /// <param name="cipherWithTag">Encrypted data with authentication tag</param>
+        /// <param name="key">32-byte decryption key</param>
+        /// <param name="nonce">12-byte nonce</param>
+        /// <returns>Decrypted data</returns>
+        public static byte[] DecryptAesGcmBytes(byte[] cipherWithTag, byte[] key, byte[] nonce)
+        {
+            if (cipherWithTag == null) throw new ArgumentNullException("cipherWithTag");
+            if (key == null) throw new ArgumentNullException("key");
+            if (nonce == null) throw new ArgumentNullException("nonce");
+
+            if (key.Length != 32) throw new ArgumentException("Key must be 32 bytes", "key");
+            if (nonce.Length != 12) throw new ArgumentException("Nonce must be 12 bytes", "nonce");
+
+            const int tagLength = 16;
+            if (cipherWithTag.Length < tagLength)
+                throw new ArgumentException("Encrypted data too short", "cipherWithTag");
+
+            IntPtr hAlg = IntPtr.Zero;
+            IntPtr hKey = IntPtr.Zero;
+
+            try
+            {
+                // Initialize algorithm provider
+                int status = BCryptOpenAlgorithmProvider(out hAlg, BCRYPT_AES_ALGORITHM, null, 0);
+                if (status != STATUS_SUCCESS) throw new CryptographicException("BCryptOpenAlgorithmProvider failed with status " + status);
+
+                // Set GCM mode
+                status = BCryptSetProperty(hAlg, BCRYPT_CHAINING_MODE,
+                    Encoding.Unicode.GetBytes(BCRYPT_CHAIN_MODE_GCM),
+                    Encoding.Unicode.GetBytes(BCRYPT_CHAIN_MODE_GCM).Length, 0);
+                if (status != STATUS_SUCCESS) throw new CryptographicException("BCryptSetProperty failed with status " + status);
+
+                // Generate key
+                status = BCryptGenerateSymmetricKey(hAlg, out hKey, IntPtr.Zero, 0, key, key.Length, 0);
+                if (status != STATUS_SUCCESS) throw new CryptographicException("BCryptGenerateSymmetricKey failed with status " + status);
+
+                // Separate ciphertext and tag
+                int encryptedDataLength = cipherWithTag.Length - tagLength;
+                byte[] encryptedData = new byte[encryptedDataLength];
+                byte[] tag = new byte[tagLength];
+                Buffer.BlockCopy(cipherWithTag, 0, encryptedData, 0, encryptedDataLength);
+                Buffer.BlockCopy(cipherWithTag, encryptedDataLength, tag, 0, tagLength);
+
+                var authInfo = BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO.Initialize();
+                var nonceHandle = GCHandle.Alloc(nonce, GCHandleType.Pinned);
+                var tagHandle = GCHandle.Alloc(tag, GCHandleType.Pinned);
+
+                try
+                {
+                    authInfo.pbNonce = nonceHandle.AddrOfPinnedObject();
+                    authInfo.cbNonce = nonce.Length;
+                    authInfo.pbTag = tagHandle.AddrOfPinnedObject();
+                    authInfo.cbTag = tagLength;
+
+                    // Get required size
+                    int plainTextLength;
+                    status = BCryptDecrypt(hKey, encryptedData, encryptedData.Length, ref authInfo,
+                        null, 0, null, 0, out plainTextLength, 0);
+                    if (status != STATUS_SUCCESS) throw new CryptographicException("BCryptDecrypt size failed with status " + status);
+
+                    byte[] plainText = new byte[plainTextLength];
+
+                    // Decrypt
+                    int bytesWritten;
+                    status = BCryptDecrypt(hKey, encryptedData, encryptedData.Length, ref authInfo,
+                        null, 0, plainText, plainText.Length, out bytesWritten, 0);
+                    if (status != STATUS_SUCCESS) throw new CryptographicException("BCryptDecrypt failed with status " + status);
+
+                    byte[] result = new byte[bytesWritten];
+                    Buffer.BlockCopy(plainText, 0, result, 0, bytesWritten);
+
+                    // Clear sensitive data
+                    Array.Clear(encryptedData, 0, encryptedData.Length);
+                    Array.Clear(tag, 0, tag.Length);
+                    Array.Clear(plainText, 0, plainText.Length);
+
+                    return result;
+                }
+                finally
+                {
+                    if (nonceHandle.IsAllocated) nonceHandle.Free();
+                    if (tagHandle.IsAllocated) tagHandle.Free();
+                }
+            }
+            finally
+            {
+                if (hKey != IntPtr.Zero) BCryptDestroyKey(hKey);
+                if (hAlg != IntPtr.Zero) BCryptCloseAlgorithmProvider(hAlg, 0);
+            }
+        }
     }
 }

--- a/net481PB/test.cs
+++ b/net481PB/test.cs
@@ -2,6 +2,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SecureLibrary;
 using System;
+using System.Security.Cryptography;
 
 namespace SecureLibrary.Tests
 {
@@ -91,6 +92,229 @@ namespace SecureLibrary.Tests
             
             // Assert
             Assert.IsTrue(isValid);
+        }
+
+        // Password-based AES-GCM encryption tests
+        [TestMethod]
+        public void EncryptAesGcmWithPassword_ShouldEncryptAndDecryptSuccessfully()
+        {
+            // Arrange
+            string plainText = "This is a test string for password-based encryption";
+            string password = "mySecurePassword123";
+            
+            // Act
+            string encrypted = EncryptionHelper.EncryptAesGcmWithPassword(plainText, password);
+            string decrypted = EncryptionHelper.DecryptAesGcmWithPassword(encrypted, password);
+            
+            // Assert
+            Assert.AreEqual(plainText, decrypted);
+        }
+
+        [TestMethod]
+        public void EncryptAesGcmWithPassword_CustomIterations_ShouldWork()
+        {
+            // Arrange
+            string plainText = "Test with custom iterations";
+            string password = "myPassword";
+            int iterations = 5000;
+            
+            // Act
+            string encrypted = EncryptionHelper.EncryptAesGcmWithPassword(plainText, password, iterations);
+            string decrypted = EncryptionHelper.DecryptAesGcmWithPassword(encrypted, password, iterations);
+            
+            // Assert
+            Assert.AreEqual(plainText, decrypted);
+        }
+
+        [TestMethod]
+        public void EncryptAesGcmWithPassword_DifferentIterationsShouldFail()
+        {
+            // Arrange
+            string plainText = "Test with different iterations";
+            string password = "myPassword";
+            int encryptIterations = 2000;
+            int decryptIterations = 5000;
+            
+            // Act
+            string encrypted = EncryptionHelper.EncryptAesGcmWithPassword(plainText, password, encryptIterations);
+            
+            // Assert - Should throw exception due to wrong iterations
+            Assert.ThrowsException<CryptographicException>(() => 
+                EncryptionHelper.DecryptAesGcmWithPassword(encrypted, password, decryptIterations));
+        }
+
+        [TestMethod]
+        public void GenerateSalt_ShouldGenerateValidSalt()
+        {
+            // Act
+            string salt = EncryptionHelper.GenerateSalt();
+            
+            // Assert
+            Assert.IsNotNull(salt);
+            Assert.AreEqual(24, salt.Length); // 16 bytes = 24 chars in base64
+            
+            // Validate it's valid base64
+            byte[] saltBytes = Convert.FromBase64String(salt);
+            Assert.AreEqual(16, saltBytes.Length);
+        }
+
+        [TestMethod]
+        public void GenerateSalt_CustomLength_ShouldWork()
+        {
+            // Arrange
+            int saltLength = 32;
+            
+            // Act
+            string salt = EncryptionHelper.GenerateSalt(saltLength);
+            
+            // Assert
+            Assert.IsNotNull(salt);
+            
+            // Validate it's valid base64 and correct length
+            byte[] saltBytes = Convert.FromBase64String(salt);
+            Assert.AreEqual(32, saltBytes.Length);
+        }
+
+        [TestMethod]
+        public void GenerateSalt_InvalidLength_ShouldThrowException()
+        {
+            // Arrange
+            int tooSmall = 4;  // Below minimum of 8
+            int tooLarge = 128; // Above maximum of 64
+            
+            // Act & Assert
+            Assert.ThrowsException<ArgumentException>(() => EncryptionHelper.GenerateSalt(tooSmall));
+            Assert.ThrowsException<ArgumentException>(() => EncryptionHelper.GenerateSalt(tooLarge));
+        }
+
+        [TestMethod]
+        public void EncryptAesGcmWithPasswordAndSalt_ShouldWork()
+        {
+            // Arrange
+            string plainText = "Test with custom salt";
+            string password = "myPassword";
+            string salt = EncryptionHelper.GenerateSalt();
+            
+            // Act
+            string encrypted = EncryptionHelper.EncryptAesGcmWithPasswordAndSalt(plainText, password, salt);
+            string decrypted = EncryptionHelper.DecryptAesGcmWithPassword(encrypted, password);
+            
+            // Assert
+            Assert.AreEqual(plainText, decrypted);
+        }
+
+        [TestMethod]
+        public void EncryptAesGcmWithPasswordAndSalt_CustomIterations_ShouldWork()
+        {
+            // Arrange
+            string plainText = "Test with custom salt and iterations";
+            string password = "myPassword";
+            string salt = EncryptionHelper.GenerateSalt(24);
+            int iterations = 3000;
+            
+            // Act
+            string encrypted = EncryptionHelper.EncryptAesGcmWithPasswordAndSalt(plainText, password, salt, iterations);
+            string decrypted = EncryptionHelper.DecryptAesGcmWithPassword(encrypted, password, iterations);
+            
+            // Assert
+            Assert.AreEqual(plainText, decrypted);
+        }
+
+        [TestMethod]
+        public void PasswordBasedEncryption_CrossCompatibility_ShouldWork()
+        {
+            // Test that the same password produces different encrypted results (due to random salt/nonce)
+            string plainText = "Same text, different encryption";
+            string password = "myPassword";
+            
+            // Act - Encrypt same text twice
+            string encrypted1 = EncryptionHelper.EncryptAesGcmWithPassword(plainText, password);
+            string encrypted2 = EncryptionHelper.EncryptAesGcmWithPassword(plainText, password);
+            
+            // Assert - Results should be different due to random salt/nonce
+            Assert.AreNotEqual(encrypted1, encrypted2);
+            
+            // But both should decrypt to the same plaintext
+            string decrypted1 = EncryptionHelper.DecryptAesGcmWithPassword(encrypted1, password);
+            string decrypted2 = EncryptionHelper.DecryptAesGcmWithPassword(encrypted2, password);
+            
+            Assert.AreEqual(plainText, decrypted1);
+            Assert.AreEqual(plainText, decrypted2);
+        }
+
+        [TestMethod]
+        public void PasswordBasedEncryption_InvalidInputs_ShouldThrowException()
+        {
+            // Test null inputs
+            Assert.ThrowsException<ArgumentNullException>(() => 
+                EncryptionHelper.EncryptAesGcmWithPassword(null, "password"));
+            Assert.ThrowsException<ArgumentNullException>(() => 
+                EncryptionHelper.EncryptAesGcmWithPassword("text", null));
+            Assert.ThrowsException<ArgumentNullException>(() => 
+                EncryptionHelper.DecryptAesGcmWithPassword(null, "password"));
+            Assert.ThrowsException<ArgumentNullException>(() => 
+                EncryptionHelper.DecryptAesGcmWithPassword("data", null));
+        }
+
+        [TestMethod]
+        public void PasswordBasedEncryption_InvalidIterations_ShouldThrowException()
+        {
+            // Arrange
+            string plainText = "Test invalid iterations";
+            string password = "myPassword";
+            int tooLow = 500;   // Below minimum of 1000
+            int tooHigh = 200000; // Above maximum of 100000
+            
+            // Act & Assert
+            Assert.ThrowsException<ArgumentException>(() => 
+                EncryptionHelper.EncryptAesGcmWithPassword(plainText, password, tooLow));
+            Assert.ThrowsException<ArgumentException>(() => 
+                EncryptionHelper.EncryptAesGcmWithPassword(plainText, password, tooHigh));
+        }
+
+        [TestMethod]
+        public void PasswordBasedEncryption_LargeData_ShouldWork()
+        {
+            // Arrange
+            string largeText = new string('A', 10000); // 10KB of data
+            string password = "myPassword";
+            
+            // Act
+            string encrypted = EncryptionHelper.EncryptAesGcmWithPassword(largeText, password);
+            string decrypted = EncryptionHelper.DecryptAesGcmWithPassword(encrypted, password);
+            
+            // Assert
+            Assert.AreEqual(largeText, decrypted);
+        }
+
+        [TestMethod]
+        public void PasswordBasedEncryption_SpecialCharacters_ShouldWork()
+        {
+            // Arrange
+            string specialText = "Special chars: !@#$%^&*()_+-=[]{}|;':\",./<>?`~";
+            string password = "Password with spaces and symbols: !@#";
+            
+            // Act
+            string encrypted = EncryptionHelper.EncryptAesGcmWithPassword(specialText, password);
+            string decrypted = EncryptionHelper.DecryptAesGcmWithPassword(encrypted, password);
+            
+            // Assert
+            Assert.AreEqual(specialText, decrypted);
+        }
+
+        [TestMethod]
+        public void PasswordBasedEncryption_UnicodeCharacters_ShouldWork()
+        {
+            // Arrange
+            string unicodeText = "Unicode: 你好世界 🌍 🚀 こんにちは";
+            string password = "Unicode password: パスワード";
+            
+            // Act
+            string encrypted = EncryptionHelper.EncryptAesGcmWithPassword(unicodeText, password);
+            string decrypted = EncryptionHelper.DecryptAesGcmWithPassword(encrypted, password);
+            
+            // Assert
+            Assert.AreEqual(unicodeText, decrypted);
         }
     }
 }

--- a/net481SQL-server/invokeCGN.cs
+++ b/net481SQL-server/invokeCGN.cs
@@ -161,7 +161,7 @@ namespace SecureLibrary.SQL
             if (salt == null)
             {
                 salt = new byte[16];
-                using (var rng = new RNGCryptoServiceProvider())
+                using (var rng = RandomNumberGenerator.Create())
                 {
                     rng.GetBytes(salt);
                 }

--- a/net481SQL-server/invokeCGN.cs
+++ b/net481SQL-server/invokeCGN.cs
@@ -98,24 +98,198 @@ namespace SecureLibrary.SQL
             }
         }
 
-        public static string EncryptAesGcm(string plainText, string base64Key, string base64Nonce)
+        /// <summary>
+        /// Encrypts string using AES-GCM with password-based key derivation
+        /// </summary>
+        /// <param name="plainText">Text to encrypt</param>
+        /// <param name="password">Password for key derivation</param>
+        /// <param name="salt">Salt for key derivation (optional, will generate if null)</param>
+        /// <param name="iterations">PBKDF2 iteration count (default: 2000)</param>
+        /// <returns>Base64 encoded encrypted data with salt, nonce, and tag</returns>
+        public static string EncryptAesGcmWithPassword(string plainText, string password, byte[] salt = null, int iterations = 2000)
         {
             if (plainText == null) throw new ArgumentNullException("plainText");
-            if (string.IsNullOrEmpty(base64Key)) throw new ArgumentNullException("base64Key");
-            if (string.IsNullOrEmpty(base64Nonce)) throw new ArgumentNullException("base64Nonce");
+            if (string.IsNullOrEmpty(password)) throw new ArgumentNullException("password");
 
-            // Convert Base64 strings to byte arrays
-            byte[] key = Convert.FromBase64String(base64Key);
-            byte[] nonce = Convert.FromBase64String(base64Nonce);
+            byte[] plainBytes = Encoding.UTF8.GetBytes(plainText);
+            byte[] encryptedBytes = EncryptAesGcmBytes(plainBytes, password, salt, iterations);
+            
+            // Clear sensitive data
+            Array.Clear(plainBytes, 0, plainBytes.Length);
+            
+            return Convert.ToBase64String(encryptedBytes);
+        }
 
-            if (key.Length != 32) throw new ArgumentException("Key must be 32 bytes", "base64Key");
-            if (nonce.Length != 12) throw new ArgumentException("Nonce must be 12 bytes", "base64Nonce");
+        /// <summary>
+        /// Decrypts string using AES-GCM with password-based key derivation
+        /// </summary>
+        /// <param name="base64EncryptedData">Base64 encoded encrypted data</param>
+        /// <param name="password">Password for key derivation</param>
+        /// <param name="iterations">PBKDF2 iteration count (default: 2000)</param>
+        /// <returns>Decrypted text</returns>
+        public static string DecryptAesGcmWithPassword(string base64EncryptedData, string password, int iterations = 2000)
+        {
+            if (string.IsNullOrEmpty(base64EncryptedData)) throw new ArgumentNullException("base64EncryptedData");
+            if (string.IsNullOrEmpty(password)) throw new ArgumentNullException("password");
+
+            byte[] encryptedBytes = Convert.FromBase64String(base64EncryptedData);
+            byte[] decryptedBytes = DecryptAesGcmBytes(encryptedBytes, password, iterations);
+            
+            string result = Encoding.UTF8.GetString(decryptedBytes);
+            
+            // Clear sensitive data
+            Array.Clear(encryptedBytes, 0, encryptedBytes.Length);
+            Array.Clear(decryptedBytes, 0, decryptedBytes.Length);
+            
+            return result;
+        }
+
+        /// <summary>
+        /// Encrypts byte array using AES-GCM with password-based key derivation
+        /// </summary>
+        /// <param name="plainData">Data to encrypt</param>
+        /// <param name="password">Password for key derivation</param>
+        /// <param name="salt">Salt for key derivation (optional, will generate if null)</param>
+        /// <param name="iterations">PBKDF2 iteration count (default: 2000)</param>
+        /// <returns>Encrypted data with salt, nonce, and tag</returns>
+        public static byte[] EncryptAesGcmBytes(byte[] plainData, string password, byte[] salt = null, int iterations = 2000)
+        {
+            if (plainData == null) throw new ArgumentNullException("plainData");
+            if (string.IsNullOrEmpty(password)) throw new ArgumentNullException("password");
+
+            // Generate salt if not provided
+            if (salt == null)
+            {
+                salt = new byte[16];
+                using (var rng = new RNGCryptoServiceProvider())
+                {
+                    rng.GetBytes(salt);
+                }
+            }
+
+            // Derive 32-byte key from password
+            byte[] key;
+            using (var pbkdf2 = new Rfc2898DeriveBytes(password, salt, iterations, HashAlgorithmName.SHA256))
+            {
+                key = pbkdf2.GetBytes(32);
+            }
+
+            // Generate 12-byte nonce
+            byte[] nonce = new byte[12];
+            using (var rng = new RNGCryptoServiceProvider())
+            {
+                rng.GetBytes(nonce);
+            }
+
+            byte[] encryptedData = EncryptAesGcmBytes(plainData, key, nonce);
+
+            // Combine salt + nonce + encrypted data for output
+            byte[] result = new byte[salt.Length + nonce.Length + encryptedData.Length];
+            Buffer.BlockCopy(salt, 0, result, 0, salt.Length);
+            Buffer.BlockCopy(nonce, 0, result, salt.Length, nonce.Length);
+            Buffer.BlockCopy(encryptedData, 0, result, salt.Length + nonce.Length, encryptedData.Length);
+
+            // Clear sensitive data
+            Array.Clear(key, 0, key.Length);
+            Array.Clear(nonce, 0, nonce.Length);
+            Array.Clear(encryptedData, 0, encryptedData.Length);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Decrypts byte array using AES-GCM with password-based key derivation
+        /// </summary>
+        /// <param name="encryptedData">Encrypted data with salt, nonce, and tag</param>
+        /// <param name="password">Password for key derivation</param>
+        /// <param name="iterations">PBKDF2 iteration count (default: 2000)</param>
+        /// <returns>Decrypted data</returns>
+        public static byte[] DecryptAesGcmBytes(byte[] encryptedData, string password, int iterations = 2000)
+        {
+            if (encryptedData == null) throw new ArgumentNullException("encryptedData");
+            if (string.IsNullOrEmpty(password)) throw new ArgumentNullException("password");
+
+            const int nonceLength = 12;
+            const int tagLength = 16;
+            const int minSaltLength = 8;
+            const int maxSaltLength = 64;
+
+            if (encryptedData.Length < minSaltLength + nonceLength + tagLength)
+                throw new ArgumentException("Encrypted data too short", "encryptedData");
+
+            // Determine salt length by trying different lengths
+            int saltLength = 0;
+            byte[] salt = null;
+            byte[] nonce = null;
+            byte[] cipherWithTag = null;
+            byte[] key = null;
+
+            // Try different salt lengths from minimum to maximum
+            for (int testSaltLength = minSaltLength; testSaltLength <= maxSaltLength && testSaltLength <= encryptedData.Length - nonceLength - tagLength; testSaltLength++)
+            {
+                try
+                {
+                    salt = new byte[testSaltLength];
+                    nonce = new byte[nonceLength];
+                    cipherWithTag = new byte[encryptedData.Length - testSaltLength - nonceLength];
+
+                    Buffer.BlockCopy(encryptedData, 0, salt, 0, testSaltLength);
+                    Buffer.BlockCopy(encryptedData, testSaltLength, nonce, 0, nonceLength);
+                    Buffer.BlockCopy(encryptedData, testSaltLength + nonceLength, cipherWithTag, 0, cipherWithTag.Length);
+
+                    // Try to derive key and decrypt
+                    using (var pbkdf2 = new Rfc2898DeriveBytes(password, salt, iterations, HashAlgorithmName.SHA256))
+                    {
+                        key = pbkdf2.GetBytes(32);
+                    }
+
+                    byte[] result = DecryptAesGcmBytes(cipherWithTag, key, nonce);
+                    
+                    // If we get here, decryption succeeded, so this is the correct salt length
+                    saltLength = testSaltLength;
+                    
+                    // Clear sensitive data
+                    Array.Clear(salt, 0, salt.Length);
+                    Array.Clear(nonce, 0, nonce.Length);
+                    Array.Clear(cipherWithTag, 0, cipherWithTag.Length);
+                    Array.Clear(key, 0, key.Length);
+                    
+                    return result;
+                }
+                catch
+                {
+                    // Clear arrays before trying next salt length
+                    if (salt != null) Array.Clear(salt, 0, salt.Length);
+                    if (nonce != null) Array.Clear(nonce, 0, nonce.Length);
+                    if (cipherWithTag != null) Array.Clear(cipherWithTag, 0, cipherWithTag.Length);
+                    if (key != null) Array.Clear(key, 0, key.Length);
+                    
+                    // Continue to next salt length
+                }
+            }
+
+            // If we get here, no salt length worked
+            throw new CryptographicException("Failed to decrypt data with any valid salt length");
+        }
+
+        /// <summary>
+        /// Encrypts byte array using AES-GCM with provided key and nonce
+        /// </summary>
+        /// <param name="plainData">Data to encrypt</param>
+        /// <param name="key">32-byte encryption key</param>
+        /// <param name="nonce">12-byte nonce</param>
+        /// <returns>Encrypted data with authentication tag</returns>
+        public static byte[] EncryptAesGcmBytes(byte[] plainData, byte[] key, byte[] nonce)
+        {
+            if (plainData == null) throw new ArgumentNullException("plainData");
+            if (key == null) throw new ArgumentNullException("key");
+            if (nonce == null) throw new ArgumentNullException("nonce");
+
+            if (key.Length != 32) throw new ArgumentException("Key must be 32 bytes", "key");
+            if (nonce.Length != 12) throw new ArgumentException("Nonce must be 12 bytes", "nonce");
 
             IntPtr hAlg = IntPtr.Zero;
             IntPtr hKey = IntPtr.Zero;
-            byte[] plainBytes = null;
-            byte[] tagBuffer = null;
-            byte[] cipherText = null;
 
             try
             {
@@ -133,12 +307,11 @@ namespace SecureLibrary.SQL
                 status = BCryptGenerateSymmetricKey(hAlg, out hKey, IntPtr.Zero, 0, key, key.Length, 0);
                 if (status != STATUS_SUCCESS) throw new CryptographicException("BCryptGenerateSymmetricKey failed with status " + status);
 
-                plainBytes = Encoding.UTF8.GetBytes(plainText);
                 const int tagLength = 16;  // GCM tag length
 
                 var authInfo = BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO.Initialize();
                 var nonceHandle = GCHandle.Alloc(nonce, GCHandleType.Pinned);
-                tagBuffer = new byte[tagLength];
+                var tagBuffer = new byte[tagLength];
                 var tagHandle = GCHandle.Alloc(tagBuffer, GCHandleType.Pinned);
 
                 try
@@ -150,15 +323,15 @@ namespace SecureLibrary.SQL
 
                     // Get required size
                     int cipherLength;
-                    status = BCryptEncrypt(hKey, plainBytes, plainBytes.Length, ref authInfo,
+                    status = BCryptEncrypt(hKey, plainData, plainData.Length, ref authInfo,
                         null, 0, null, 0, out cipherLength, 0);
                     if (status != STATUS_SUCCESS) throw new CryptographicException("BCryptEncrypt size failed with status " + status);
 
-                    cipherText = new byte[cipherLength];
+                    byte[] cipherText = new byte[cipherLength];
 
                     // Encrypt
                     int bytesWritten;
-                    status = BCryptEncrypt(hKey, plainBytes, plainBytes.Length, ref authInfo,
+                    status = BCryptEncrypt(hKey, plainData, plainData.Length, ref authInfo,
                         null, 0, cipherText, cipherText.Length, out bytesWritten, 0);
                     if (status != STATUS_SUCCESS) throw new CryptographicException("BCryptEncrypt failed with status " + status);
 
@@ -167,10 +340,11 @@ namespace SecureLibrary.SQL
                     Buffer.BlockCopy(cipherText, 0, result, 0, bytesWritten);
                     Buffer.BlockCopy(tagBuffer, 0, result, bytesWritten, tagLength);
 
-                    // Convert final result to Base64
-                    var base64Result = Convert.ToBase64String(result);
-                    Array.Clear(result, 0, result.Length);
-                    return base64Result;
+                    // Clear sensitive data
+                    Array.Clear(cipherText, 0, cipherText.Length);
+                    Array.Clear(tagBuffer, 0, tagBuffer.Length);
+
+                    return result;
                 }
                 finally
                 {
@@ -182,39 +356,31 @@ namespace SecureLibrary.SQL
             {
                 if (hKey != IntPtr.Zero) BCryptDestroyKey(hKey);
                 if (hAlg != IntPtr.Zero) BCryptCloseAlgorithmProvider(hAlg, 0);
-
-                // Clear sensitive data
-                if (key != null) Array.Clear(key, 0, key.Length);
-                if (nonce != null) Array.Clear(nonce, 0, nonce.Length);
-                if (plainBytes != null) Array.Clear(plainBytes, 0, plainBytes.Length);
-                if (tagBuffer != null) Array.Clear(tagBuffer, 0, tagBuffer.Length);
-                if (cipherText != null) Array.Clear(cipherText, 0, cipherText.Length);
             }
         }
 
-        public static string DecryptAesGcm(string base64CipherText, string base64Key, string base64Nonce)
+        /// <summary>
+        /// Decrypts byte array using AES-GCM with provided key and nonce
+        /// </summary>
+        /// <param name="cipherWithTag">Encrypted data with authentication tag</param>
+        /// <param name="key">32-byte decryption key</param>
+        /// <param name="nonce">12-byte nonce</param>
+        /// <returns>Decrypted data</returns>
+        public static byte[] DecryptAesGcmBytes(byte[] cipherWithTag, byte[] key, byte[] nonce)
         {
-            if (string.IsNullOrEmpty(base64CipherText)) throw new ArgumentNullException("base64CipherText");
-            if (string.IsNullOrEmpty(base64Key)) throw new ArgumentNullException("base64Key");
-            if (string.IsNullOrEmpty(base64Nonce)) throw new ArgumentNullException("base64Nonce");
+            if (cipherWithTag == null) throw new ArgumentNullException("cipherWithTag");
+            if (key == null) throw new ArgumentNullException("key");
+            if (nonce == null) throw new ArgumentNullException("nonce");
 
-            // Convert Base64 strings to byte arrays
-            byte[] cipherText = Convert.FromBase64String(base64CipherText);
-            byte[] key = Convert.FromBase64String(base64Key);
-            byte[] nonce = Convert.FromBase64String(base64Nonce);
-
-            if (key.Length != 32) throw new ArgumentException("Key must be 32 bytes", "base64Key");
-            if (nonce.Length != 12) throw new ArgumentException("Nonce must be 12 bytes", "base64Nonce");
+            if (key.Length != 32) throw new ArgumentException("Key must be 32 bytes", "key");
+            if (nonce.Length != 12) throw new ArgumentException("Nonce must be 12 bytes", "nonce");
 
             const int tagLength = 16;
-            if (cipherText.Length < tagLength)
-                throw new ArgumentException("Encrypted data too short", "base64CipherText");
+            if (cipherWithTag.Length < tagLength)
+                throw new ArgumentException("Encrypted data too short", "cipherWithTag");
 
             IntPtr hAlg = IntPtr.Zero;
             IntPtr hKey = IntPtr.Zero;
-            byte[] encryptedData = null;
-            byte[] tag = null;
-            byte[] plainText = null;
 
             try
             {
@@ -233,11 +399,11 @@ namespace SecureLibrary.SQL
                 if (status != STATUS_SUCCESS) throw new CryptographicException("BCryptGenerateSymmetricKey failed with status " + status);
 
                 // Separate ciphertext and tag
-                int encryptedDataLength = cipherText.Length - tagLength;
-                encryptedData = new byte[encryptedDataLength];
-                tag = new byte[tagLength];
-                Buffer.BlockCopy(cipherText, 0, encryptedData, 0, encryptedDataLength);
-                Buffer.BlockCopy(cipherText, encryptedDataLength, tag, 0, tagLength);
+                int encryptedDataLength = cipherWithTag.Length - tagLength;
+                byte[] encryptedData = new byte[encryptedDataLength];
+                byte[] tag = new byte[tagLength];
+                Buffer.BlockCopy(cipherWithTag, 0, encryptedData, 0, encryptedDataLength);
+                Buffer.BlockCopy(cipherWithTag, encryptedDataLength, tag, 0, tagLength);
 
                 var authInfo = BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO.Initialize();
                 var nonceHandle = GCHandle.Alloc(nonce, GCHandleType.Pinned);
@@ -256,7 +422,7 @@ namespace SecureLibrary.SQL
                         null, 0, null, 0, out plainTextLength, 0);
                     if (status != STATUS_SUCCESS) throw new CryptographicException("BCryptDecrypt size failed with status " + status);
 
-                    plainText = new byte[plainTextLength];
+                    byte[] plainText = new byte[plainTextLength];
 
                     // Decrypt
                     int bytesWritten;
@@ -264,7 +430,15 @@ namespace SecureLibrary.SQL
                         null, 0, plainText, plainText.Length, out bytesWritten, 0);
                     if (status != STATUS_SUCCESS) throw new CryptographicException("BCryptDecrypt failed with status " + status);
 
-                    return Encoding.UTF8.GetString(plainText, 0, bytesWritten);
+                    byte[] result = new byte[bytesWritten];
+                    Buffer.BlockCopy(plainText, 0, result, 0, bytesWritten);
+
+                    // Clear sensitive data
+                    Array.Clear(encryptedData, 0, encryptedData.Length);
+                    Array.Clear(tag, 0, tag.Length);
+                    Array.Clear(plainText, 0, plainText.Length);
+
+                    return result;
                 }
                 finally
                 {
@@ -276,15 +450,75 @@ namespace SecureLibrary.SQL
             {
                 if (hKey != IntPtr.Zero) BCryptDestroyKey(hKey);
                 if (hAlg != IntPtr.Zero) BCryptCloseAlgorithmProvider(hAlg, 0);
-
-                // Clear sensitive data
-                if (key != null) Array.Clear(key, 0, key.Length);
-                if (nonce != null) Array.Clear(nonce, 0, nonce.Length);
-                if (cipherText != null) Array.Clear(cipherText, 0, cipherText.Length);
-                if (encryptedData != null) Array.Clear(encryptedData, 0, encryptedData.Length);
-                if (tag != null) Array.Clear(tag, 0, tag.Length);
-                if (plainText != null) Array.Clear(plainText, 0, plainText.Length);
             }
+        }
+
+        /// <summary>
+        /// Encrypts string using AES-GCM with provided key and nonce (legacy method)
+        /// </summary>
+        /// <param name="plainText">Text to encrypt</param>
+        /// <param name="base64Key">Base64 encoded 32-byte key</param>
+        /// <param name="base64Nonce">Base64 encoded 12-byte nonce</param>
+        /// <returns>Base64 encoded encrypted data with authentication tag</returns>
+        public static string EncryptAesGcm(string plainText, string base64Key, string base64Nonce)
+        {
+            if (plainText == null) throw new ArgumentNullException("plainText");
+            if (string.IsNullOrEmpty(base64Key)) throw new ArgumentNullException("base64Key");
+            if (string.IsNullOrEmpty(base64Nonce)) throw new ArgumentNullException("base64Nonce");
+
+            // Convert Base64 strings to byte arrays
+            byte[] key = Convert.FromBase64String(base64Key);
+            byte[] nonce = Convert.FromBase64String(base64Nonce);
+
+            if (key.Length != 32) throw new ArgumentException("Key must be 32 bytes", "base64Key");
+            if (nonce.Length != 12) throw new ArgumentException("Nonce must be 12 bytes", "base64Nonce");
+
+            byte[] plainBytes = Encoding.UTF8.GetBytes(plainText);
+            byte[] encryptedBytes = EncryptAesGcmBytes(plainBytes, key, nonce);
+            
+            // Clear sensitive data
+            Array.Clear(key, 0, key.Length);
+            Array.Clear(nonce, 0, nonce.Length);
+            Array.Clear(plainBytes, 0, plainBytes.Length);
+            
+            return Convert.ToBase64String(encryptedBytes);
+        }
+
+        /// <summary>
+        /// Decrypts string using AES-GCM with provided key and nonce (legacy method)
+        /// </summary>
+        /// <param name="base64CipherText">Base64 encoded encrypted data</param>
+        /// <param name="base64Key">Base64 encoded 32-byte key</param>
+        /// <param name="base64Nonce">Base64 encoded 12-byte nonce</param>
+        /// <returns>Decrypted text</returns>
+        public static string DecryptAesGcm(string base64CipherText, string base64Key, string base64Nonce)
+        {
+            if (string.IsNullOrEmpty(base64CipherText)) throw new ArgumentNullException("base64CipherText");
+            if (string.IsNullOrEmpty(base64Key)) throw new ArgumentNullException("base64Key");
+            if (string.IsNullOrEmpty(base64Nonce)) throw new ArgumentNullException("base64Nonce");
+
+            // Convert Base64 strings to byte arrays
+            byte[] cipherText = Convert.FromBase64String(base64CipherText);
+            byte[] key = Convert.FromBase64String(base64Key);
+            byte[] nonce = Convert.FromBase64String(base64Nonce);
+
+            if (key.Length != 32) throw new ArgumentException("Key must be 32 bytes", "base64Key");
+            if (nonce.Length != 12) throw new ArgumentException("Nonce must be 12 bytes", "base64Nonce");
+
+            const int tagLength = 16;
+            if (cipherText.Length < tagLength)
+                throw new ArgumentException("Encrypted data too short", "base64CipherText");
+
+            byte[] decryptedBytes = DecryptAesGcmBytes(cipherText, key, nonce);
+            string result = Encoding.UTF8.GetString(decryptedBytes);
+            
+            // Clear sensitive data
+            Array.Clear(cipherText, 0, cipherText.Length);
+            Array.Clear(key, 0, key.Length);
+            Array.Clear(nonce, 0, nonce.Length);
+            Array.Clear(decryptedBytes, 0, decryptedBytes.Length);
+            
+            return result;
         }
     }
 }

--- a/net481SQL-server/invokeCGN.cs
+++ b/net481SQL-server/invokeCGN.cs
@@ -183,11 +183,12 @@ namespace SecureLibrary.SQL
 
             byte[] encryptedData = EncryptAesGcmBytes(plainData, key, nonce);
 
-            // Combine salt + nonce + encrypted data for output
-            byte[] result = new byte[salt.Length + nonce.Length + encryptedData.Length];
-            Buffer.BlockCopy(salt, 0, result, 0, salt.Length);
-            Buffer.BlockCopy(nonce, 0, result, salt.Length, nonce.Length);
-            Buffer.BlockCopy(encryptedData, 0, result, salt.Length + nonce.Length, encryptedData.Length);
+            // Combine salt length (4 bytes) + salt + nonce + encrypted data for output
+            byte[] result = new byte[4 + salt.Length + nonce.Length + encryptedData.Length];
+            Buffer.BlockCopy(BitConverter.GetBytes(salt.Length), 0, result, 0, 4);
+            Buffer.BlockCopy(salt, 0, result, 4, salt.Length);
+            Buffer.BlockCopy(nonce, 0, result, 4 + salt.Length, nonce.Length);
+            Buffer.BlockCopy(encryptedData, 0, result, 4 + salt.Length + nonce.Length, encryptedData.Length);
 
             // Clear sensitive data
             Array.Clear(key, 0, key.Length);
@@ -211,65 +212,32 @@ namespace SecureLibrary.SQL
 
             const int nonceLength = 12;
             const int tagLength = 16;
-            const int minSaltLength = 8;
-            const int maxSaltLength = 64;
-
-            if (encryptedData.Length < minSaltLength + nonceLength + tagLength)
+            const int headerLength = 4; // 4 bytes to store salt length
+            if (encryptedData.Length < headerLength + nonceLength + tagLength)
                 throw new ArgumentException("Encrypted data too short", "encryptedData");
-
-            // Determine salt length by trying different lengths
-            int saltLength = 0;
-            byte[] salt = null;
-            byte[] nonce = null;
-            byte[] cipherWithTag = null;
+            // Extract salt length from the header
+            int saltLength = BitConverter.ToInt32(encryptedData, 0);
+            if (saltLength <= 0 || encryptedData.Length < headerLength + saltLength + nonceLength + tagLength)
+                throw new ArgumentException("Invalid salt length in encrypted data", "encryptedData");
+            byte[] salt = new byte[saltLength];
+            byte[] nonce = new byte[nonceLength];
+            byte[] cipherWithTag                                                                                        = new byte[encryptedData.Length - headerLength - saltLength - nonceLength];
             byte[] key = null;
-
-            // Try different salt lengths from minimum to maximum
-            for (int testSaltLength = minSaltLength; testSaltLength <= maxSaltLength && testSaltLength <= encryptedData.Length - nonceLength - tagLength; testSaltLength++)
+            Buffer.BlockCopy(encryptedData, headerLength, salt, 0, saltLength);
+            Buffer.BlockCopy(encryptedData, headerLength + saltLength, nonce, 0, nonceLength);
+            Buffer.BlockCopy(encryptedData, headerLength + saltLength + nonceLength, cipherWithTag, 0, cipherWithTag.Length);
+            // Derive key and decrypt
+            using (var pbkdf2 = new Rfc2898DeriveBytes(password, salt, iterations, HashAlgorithmName.SHA256))
             {
-                try
-                {
-                    salt = new byte[testSaltLength];
-                    nonce = new byte[nonceLength];
-                    cipherWithTag = new byte[encryptedData.Length - testSaltLength - nonceLength];
-
-                    Buffer.BlockCopy(encryptedData, 0, salt, 0, testSaltLength);
-                    Buffer.BlockCopy(encryptedData, testSaltLength, nonce, 0, nonceLength);
-                    Buffer.BlockCopy(encryptedData, testSaltLength + nonceLength, cipherWithTag, 0, cipherWithTag.Length);
-
-                    // Try to derive key and decrypt
-                    using (var pbkdf2 = new Rfc2898DeriveBytes(password, salt, iterations, HashAlgorithmName.SHA256))
-                    {
-                        key = pbkdf2.GetBytes(32);
-                    }
-
-                    byte[] result = DecryptAesGcmBytes(cipherWithTag, key, nonce);
-                    
-                    // If we get here, decryption succeeded, so this is the correct salt length
-                    saltLength = testSaltLength;
-                    
-                    // Clear sensitive data
-                    Array.Clear(salt, 0, salt.Length);
-                    Array.Clear(nonce, 0, nonce.Length);
-                    Array.Clear(cipherWithTag, 0, cipherWithTag.Length);
-                    Array.Clear(key, 0, key.Length);
-                    
-                    return result;
-                }
-                catch
-                {
-                    // Clear arrays before trying next salt length
-                    if (salt != null) Array.Clear(salt, 0, salt.Length);
-                    if (nonce != null) Array.Clear(nonce, 0, nonce.Length);
-                    if (cipherWithTag != null) Array.Clear(cipherWithTag, 0, cipherWithTag.Length);
-                    if (key != null) Array.Clear(key, 0, key.Length);
-                    
-                    // Continue to next salt length
-                }
+                key = pbkdf2.GetBytes(32);
             }
-
-            // If we get here, no salt length worked
-            throw new CryptographicException("Failed to decrypt data with any valid salt length");
+            byte[] result = DecryptAesGcmBytes(cipherWithTag, key, nonce);
+            // Clear sensitive data
+            Array.Clear(salt, 0, salt.Length);
+            Array.Clear(nonce, 0, nonce.Length);
+            Array.Clear(cipherWithTag, 0, cipherWithTag.Length);
+            Array.Clear(key, 0, key.Length);
+            return result;
         }
 
         /// <summary>


### PR DESCRIPTION
Add password-based AES-GCM encryption and decryption methods

Implemented methods for encrypting and decrypting text and byte arrays using AES-GCM with password-based key derivation. Added support for custom salt and iteration counts, along with comprehensive unit tests to validate functionality and edge cases, including handling of special and Unicode characters. Enhanced the GenerateSalt method for secure salt generation.