### PR TITLE
💚 update trigger-cd

### DIFF
--- a/.github/workflows/trigger-cd.yaml
+++ b/.github/workflows/trigger-cd.yaml
@@ -1,17 +1,18 @@
 name: Trigger CD on PR Merge
 
 on:
-  pull_request_target:
+  pull_request:
     types: [closed]
+
+permissions:
+  actions: write # Permission to trigger repository_dispatch
+  contents: write # Permission to write repository dispatch event
 
 jobs:
   trigger-cd:
     runs-on: ubuntu-latest
     # Only run if PR was actually merged (not just closed)
     if: github.event.pull_request.merged == true
-    permissions:
-      actions: write # Permission to trigger repository_dispatch
-      contents: write # Permission to write repository dispatch event
     
     steps:
       - name: Trigger CD workflow


### PR DESCRIPTION
to allow dependabot's trigger, permissions will defined on workflow level (not job level)

also pull_request_target to pull_request changed workflow trigger